### PR TITLE
feat: Add fallback Transaction Builder for unsupported chains

### DIFF
--- a/src/hooks/safe-apps/useTxBuilderApp.ts
+++ b/src/hooks/safe-apps/useTxBuilderApp.ts
@@ -1,15 +1,36 @@
 import { useRouter } from 'next/router'
 import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
+import { SafeAppAccessPolicyTypes } from '@safe-global/safe-gateway-typescript-sdk'
 import type { UrlObject } from 'url'
 
 import { SafeAppsTag } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
+import { useCurrentChain } from '@/hooks/useChains'
+
+// Fallback Transaction Builder configuration for chains not supported by Safe Gateway
+const FALLBACK_TX_BUILDER: SafeAppData = {
+  id: 999999,
+  url: 'https://safe-apps.dev.5afe.dev/tx-builder',
+  name: 'Transaction Builder',
+  iconUrl: 'https://safe-apps.dev.5afe.dev/tx-builder/tx-builder.png',
+  description: 'Compose custom contract interactions and batch them into a single transaction',
+  chainIds: [], // Will work for all chains
+  provider: undefined,
+  accessControl: { type: SafeAppAccessPolicyTypes.NoRestrictions },
+  tags: ['transaction-builder'],
+  features: [],
+  developerWebsite: '',
+  socialProfiles: [],
+}
 
 export const useTxBuilderApp = (): { app?: SafeAppData; link: UrlObject } | undefined => {
   const [matchingApps] = useRemoteSafeApps(SafeAppsTag.TX_BUILDER)
   const router = useRouter()
-  const app = matchingApps?.[0]
+  const chain = useCurrentChain()
+
+  // Use remote app if available, otherwise use fallback
+  const app = matchingApps?.[0] || (chain ? FALLBACK_TX_BUILDER : undefined)
 
   if (!app) {
     return undefined


### PR DESCRIPTION
Added a hardcoded fallback configuration for the Transaction Builder Safe App to ensure it appears on all chains, including those not officially supported by the Safe Gateway API. This allows self-hosted Safe instances to use the Transaction Builder without requiring Safe team intervention.

The fallback will be used when the Safe Gateway API does not return a Transaction Builder app for the current chain. If the API returns one, it will be used as the primary option.

## What it solves

Resolves #

## How this PR fixes it

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
