### PR TITLE
feat: Enable SAFE_APPS feature for chain 957

### DIFF
--- a/src/hooks/loadables/useLoadChains.ts
+++ b/src/hooks/loadables/useLoadChains.ts
@@ -1,11 +1,26 @@
 import { useEffect } from 'react'
-import { getChainsConfig, type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { getChainsConfig, type ChainInfo, FEATURES } from '@safe-global/safe-gateway-typescript-sdk'
 import useAsync, { type AsyncResult } from '../useAsync'
 import { logError, Errors } from '@/services/exceptions'
 
 const getConfigs = async (): Promise<ChainInfo[]> => {
   const data = await getChainsConfig()
-  return data.results || []
+  const chains = data.results || []
+
+  // Add missing features for self-hosted chains
+  return chains.map((chain) => {
+    // For chain 957, ensure SAFE_APPS feature is enabled
+    if (chain.chainId === '957') {
+      const features = chain.features || []
+      if (!features.includes(FEATURES.SAFE_APPS)) {
+        return {
+          ...chain,
+          features: [...features, FEATURES.SAFE_APPS],
+        }
+      }
+    }
+    return chain
+  })
 }
 
 export const useLoadChains = (): AsyncResult<ChainInfo[]> => {


### PR DESCRIPTION
Added logic to inject the SAFE_APPS feature flag for chain 957 during chain configuration loading. This ensures that Safe Apps functionality, including the Transaction Builder, is available on chain 957 even if the Safe Gateway API doesn't include this feature in its response.

This change is necessary for self-hosted Safe instances that need to enable Safe Apps on custom chains without requiring Safe Gateway backend modifications.

## What it solves

Resolves #

## How this PR fixes it

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
