### PR TITLE
fix: Add fallback to nativeCurrency.logoUri for chain logo display

### DIFF
--- a/src/components/common/ChainIndicator/index.tsx
+++ b/src/components/common/ChainIndicator/index.tsx
@@ -25,6 +25,12 @@ const fallbackChainConfig = {
     textColor: '#000',
   },
   chainLogoUri: null,
+  nativeCurrency: {
+    name: 'Unknown',
+    symbol: 'UNKNOWN',
+    decimals: 18,
+    logoUri: null,
+  },
 }
 
 const ChainIndicator = ({
@@ -67,7 +73,7 @@ const ChainIndicator = ({
     >
       {showLogo && (
         <img
-          src={chainConfig.chainLogoUri ?? undefined}
+          src={chainConfig.chainLogoUri || chainConfig.nativeCurrency.logoUri || undefined}
           alt={`${chainConfig.chainName} Logo`}
           width={24}
           height={24}


### PR DESCRIPTION
Some chains (like Lyra Mainnet with chain ID 957) don't provide a chainLogoUri in their API response. Instead, they only provide the logo URL in nativeCurrency.logoUri field.

This commit updates the ChainIndicator component to fallback to nativeCurrency.logoUri when chainLogoUri is missing or empty, ensuring chain logos display correctly for all chains.

Changes:
- Updated fallbackChainConfig to include nativeCurrency property
- Modified img src to use: chainLogoUri || nativeCurrency.logoUri || undefined

## What it solves

Resolves #

## How this PR fixes it

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
